### PR TITLE
🐛fix: Prevent permalink popup to display estate perimeter coordinates…

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,8 +284,8 @@
             showPOItoolTip(event);
             // Update permalink popup infomration
             if (POIpermalinkPopupExists) {
-              if (map.hasFeatureAtPixel(event.pixel)) {
-                const feature = map.forEachFeatureAtPixel(event.pixel, (feature) => feature);
+              const feature = map.forEachFeatureAtPixel(event.pixel, (feature) => feature);
+              if (map.hasFeatureAtPixel(event.pixel) && feature?.values_.featureType === 'poi') {
                 const coordinates = feature.values_.geometry.flatCoordinates;
                 // Generate POI permalink popup
                 const DCLcoords = mapToDecentralandCoords(coordinates)


### PR DESCRIPTION
… on hover